### PR TITLE
ergonomics and bug fix

### DIFF
--- a/village/devices/led_strip.py
+++ b/village/devices/led_strip.py
@@ -1,7 +1,7 @@
 import traceback
 from typing import Any
 
-from pi5neo import Pi5Neo, EPixelType
+from pi5neo import EPixelType, Pi5Neo
 
 from village.classes.null_classes import NullLEDStrip
 from village.scripts.log import log

--- a/village/gui/data_layout.py
+++ b/village/gui/data_layout.py
@@ -172,7 +172,10 @@ class TableView(QTableView):
                         )
                         if reply == QMessageBox.No:
                             return
-                    super().mouseDoubleClickEvent(event)
+                    try:
+                        super().mouseDoubleClickEvent(event)
+                    except RuntimeError:
+                        return
                     self.save_changes_in_df()
             elif flags & Qt.ItemIsEditable:
                 text = "Wait until the box is empty or synchronization is complete"
@@ -224,7 +227,10 @@ class TableView(QTableView):
             self.clearSelection()
 
     def save_changes_in_df(self, update: bool = True) -> None:
-        model = self._model()
+        try:
+            model = self._model()
+        except RuntimeError:
+            return
         if update:
             model.complete_df.loc[model.df.index] = model.df
         if manager.table == DataTable.SUBJECTS:

--- a/village/gui/settings_layout.py
+++ b/village/gui/settings_layout.py
@@ -764,8 +764,7 @@ class SettingsLayout(Layout):
             pass
 
         try:
-            settings.set("FAVOURITE_TASK",
-                         self.favourite_task_combobox.currentText())
+            settings.set("FAVOURITE_TASK", self.favourite_task_combobox.currentText())
         except Exception:
             pass
 
@@ -883,11 +882,17 @@ class SettingsLayout(Layout):
         elif s.key == "FAVOURITE_TASK":
             possible_values = ["None"] + list(manager.tasks.keys())
             value = self._get(s.key)
-            index = (possible_values.index(value)
-                     if value in possible_values else 0)
+            index = possible_values.index(value) if value in possible_values else 0
             self.favourite_task_combobox = self.create_and_add_combo_box(
-                s.key, row, column + width, size2, 2,
-                possible_values, index, self.settings_changed)
+                s.key,
+                row,
+                column + width,
+                size2,
+                2,
+                possible_values,
+                index,
+                self.settings_changed,
+            )
             self.favourite_task_combobox.setProperty("type", type)
 
         elif s.value_type in (str, int, float):

--- a/village/gui/settings_layout.py
+++ b/village/gui/settings_layout.py
@@ -205,6 +205,9 @@ class SettingsLayout(Layout):
         with suppress(AttributeError, RuntimeError):
             self._pending["SOUND_DEVICE"] = self.sound_device_combobox.currentText()
         with suppress(AttributeError, RuntimeError):
+            txt = self.favourite_task_combobox.currentText()
+            self._pending["FAVOURITE_TASK"] = txt
+        with suppress(AttributeError, RuntimeError):
             self._pending["PROJECT_DIRECTORY"] = (
                 self.project_directory_combobox.currentText()
             )
@@ -760,6 +763,12 @@ class SettingsLayout(Layout):
         except Exception:
             pass
 
+        try:
+            settings.set("FAVOURITE_TASK",
+                         self.favourite_task_combobox.currentText())
+        except Exception:
+            pass
+
         cam_corridor.change = True
         cam_box.change = True
 
@@ -870,6 +879,16 @@ class SettingsLayout(Layout):
                 self.change_sound_device,
             )
             self.sound_device_combobox.setProperty("type", type)
+
+        elif s.key == "FAVOURITE_TASK":
+            possible_values = ["None"] + list(manager.tasks.keys())
+            value = self._get(s.key)
+            index = (possible_values.index(value)
+                     if value in possible_values else 0)
+            self.favourite_task_combobox = self.create_and_add_combo_box(
+                s.key, row, column + width, size2, 2,
+                possible_values, index, self.settings_changed)
+            self.favourite_task_combobox.setProperty("type", type)
 
         elif s.value_type in (str, int, float):
             project_dir = self._get("PROJECT_DIRECTORY")

--- a/village/gui/tasks_layout.py
+++ b/village/gui/tasks_layout.py
@@ -71,14 +71,12 @@ class TasksLayout(Layout):
         self.line_edits: dict[str, LineEdit] = {}
         self.tasks_button.setDisabled(True)
 
-        # Centered between menu end (col 25) and right panel (col 89): (89-25-20)//2=22
-        _btn_col = C_COL + (SETTINGS_COL - C_COL - 20) // 2  # = 47
         self.run_task_button = self.create_and_add_button(
             "RUN TASK",
             C_ROW,
-            _btn_col,
-            20,
-            2,
+            C_COL + 24,
+            34,
+            3,
             self.run_task_button_clicked,
             "Run the selected task",
             "powderblue",
@@ -86,6 +84,7 @@ class TasksLayout(Layout):
 
         self._draw_menu()
         self._draw_content_area()
+        self._draw_subject_selector()
         self.check_buttons()
 
         favourite = settings.get("FAVOURITE_TASK")
@@ -145,6 +144,38 @@ class TasksLayout(Layout):
             cls = manager.tasks[name]
             self.select_task(cls, name)
 
+    # ── Subject selector ─────────────────────────────────────────────────────
+    def _draw_subject_selector(self) -> None:
+        mylist = ["None"] + manager.subjects.df["name"].tolist()
+        self.possible_subjects = [x for x in mylist
+                                  if not pd.isna(x)
+                                  and not (isinstance(x, str)
+                                           and x.strip() == "")]
+        last_subject = settings.get("LAST_SUBJECT")
+        if last_subject in self.possible_subjects:
+            self.subject_index = self.possible_subjects.index(last_subject)
+        else:
+            self.subject_index = 0
+
+        self.subject_label = self.create_and_add_label(
+            "Subject", C_ROW, C_COL + 4, 14, 1, "black")
+        self.subject_combo = self.create_and_add_combo_box(
+            "subject", C_ROW + 1, C_COL + 4, 16, 2, self.possible_subjects,
+            self.subject_index, self.select_subject)
+        self.subject_up_button = self.create_and_add_button(
+            "▲", C_ROW + 1, C_COL + 20, 2, 1, lambda: self._step_subject(-1),
+            "Previous subject")
+        self.subject_down_button = self.create_and_add_button(
+            "▼", C_ROW + 2, C_COL + 20, 2, 1, lambda: self._step_subject(1),
+            "Next subject")
+
+    def _step_subject(self, delta: int) -> None:
+        if not self.possible_subjects:
+            return
+        n = len(self.possible_subjects)
+        self.subject_combo.setCurrentIndex(
+            (self.subject_combo.currentIndex() + delta) % n)
+
     # ── Content area ───────────────────────────────────────────────────────────
 
     def _draw_content_area(self) -> None:
@@ -193,6 +224,11 @@ class TasksLayout(Layout):
     # ── Button state management ────────────────────────────────────────────────
 
     def check_buttons(self) -> None:
+        subject_enabled = (not manager.state.task_is_running()
+                           and (self.testing_training or self.selected != ""))
+        self.subject_combo.setEnabled(subject_enabled)
+        self.subject_up_button.setEnabled(subject_enabled)
+        self.subject_down_button.setEnabled(subject_enabled)
         if manager.state.task_is_running():
             self.run_task_button.setEnabled(False)
             self.menu_list.setEnabled(False)
@@ -219,7 +255,6 @@ class TasksLayout(Layout):
 
     def select_task(self, cls: Type, name: str) -> None:
         if issubclass(cls, TaskBase):
-            self.subject_index = 0
             self.testing_training = False
             self.selected = name
             self.central_sub_layout.delete_optional_widgets("optional")
@@ -250,10 +285,9 @@ class TasksLayout(Layout):
             row_h = self.central_sub_layout.row_height
             self.info_scroll.setFixedSize(60 * col_w, 30 * row_h)
             self.central_sub_layout.addWidget(self.info_scroll, 2, 2, 30, 60)
-            self.create_gui_properties(testing_training=False)
+            self._apply_current_subject(testing_training=False)
 
     def training_button_clicked(self) -> None:
-        self.subject_index = 0
         self.testing_training = True
         self.selected = ""
         self.central_sub_layout.delete_optional_widgets("optional")
@@ -262,7 +296,15 @@ class TasksLayout(Layout):
         self.right_layout_general.delete_optional_widgets("optional2")
         self.check_buttons()
         manager.reset_subject_task_training()
-        self.create_gui_properties(testing_training=True)
+        self._apply_current_subject(testing_training=True)
+
+    def _apply_current_subject(self, testing_training: bool) -> None:
+        """Loads the selector's subject, or builds defaults when None."""
+        subject = self.subject_combo.currentText()
+        if subject != "None":
+            self.select_subject(subject, "subject")
+        else:
+            self.create_gui_properties(testing_training=testing_training)
 
     # ── GUI properties panel ───────────────────────────────────────────────────
 
@@ -271,29 +313,6 @@ class TasksLayout(Layout):
         self.central_sub_layout.delete_optional_widgets("optional2")
         self.right_layout_general.delete_optional_widgets("optional2")
         self.restart_tab_panel()
-
-        self.subject_label = self.right_layout_general.create_and_add_label(
-            "Subject", 0, 2, 20, 2, "black"
-        )
-        self.subject_label.setProperty("type", "optional")
-
-        mylist = ["None"] + manager.subjects.df["name"].tolist()
-        self.possible_subjects = [
-            x
-            for x in mylist
-            if not pd.isna(x) and not (isinstance(x, str) and x.strip() == "")
-        ]
-        self.subject_combo = self.right_layout_general.create_and_add_combo_box(
-            "subject",
-            0,
-            32,
-            30,
-            2,
-            self.possible_subjects,
-            self.subject_index,
-            self.select_subject,
-        )
-        self.subject_combo.setProperty("type", "optional")
 
         remove_names = [
             "next_task",
@@ -358,6 +377,8 @@ class TasksLayout(Layout):
 
     def select_subject(self, value: str, key: str) -> None:
         self.subject_index = self.subject_combo.currentIndex()
+        settings.set("LAST_SUBJECT", value)
+        settings.sync()
         current_value = ""
         if value != "None":
             manager.subject.subject_series = manager.subjects.get_last_entry(

--- a/village/gui/tasks_layout.py
+++ b/village/gui/tasks_layout.py
@@ -147,10 +147,11 @@ class TasksLayout(Layout):
     # ── Subject selector ─────────────────────────────────────────────────────
     def _draw_subject_selector(self) -> None:
         mylist = ["None"] + manager.subjects.df["name"].tolist()
-        self.possible_subjects = [x for x in mylist
-                                  if not pd.isna(x)
-                                  and not (isinstance(x, str)
-                                           and x.strip() == "")]
+        self.possible_subjects = [
+            x
+            for x in mylist
+            if not pd.isna(x) and not (isinstance(x, str) and x.strip() == "")
+        ]
         last_subject = settings.get("LAST_SUBJECT")
         if last_subject in self.possible_subjects:
             self.subject_index = self.possible_subjects.index(last_subject)
@@ -158,23 +159,44 @@ class TasksLayout(Layout):
             self.subject_index = 0
 
         self.subject_label = self.create_and_add_label(
-            "Subject", C_ROW, C_COL + 4, 14, 1, "black")
+            "Subject", C_ROW, C_COL + 4, 14, 1, "black"
+        )
         self.subject_combo = self.create_and_add_combo_box(
-            "subject", C_ROW + 1, C_COL + 4, 16, 2, self.possible_subjects,
-            self.subject_index, self.select_subject)
+            "subject",
+            C_ROW + 1,
+            C_COL + 4,
+            16,
+            2,
+            self.possible_subjects,
+            self.subject_index,
+            self.select_subject,
+        )
         self.subject_up_button = self.create_and_add_button(
-            "▲", C_ROW + 1, C_COL + 20, 2, 1, lambda: self._step_subject(-1),
-            "Previous subject")
+            "▲",
+            C_ROW + 1,
+            C_COL + 20,
+            2,
+            1,
+            lambda: self._step_subject(-1),
+            "Previous subject",
+        )
         self.subject_down_button = self.create_and_add_button(
-            "▼", C_ROW + 2, C_COL + 20, 2, 1, lambda: self._step_subject(1),
-            "Next subject")
+            "▼",
+            C_ROW + 2,
+            C_COL + 20,
+            2,
+            1,
+            lambda: self._step_subject(1),
+            "Next subject",
+        )
 
     def _step_subject(self, delta: int) -> None:
         if not self.possible_subjects:
             return
         n = len(self.possible_subjects)
         self.subject_combo.setCurrentIndex(
-            (self.subject_combo.currentIndex() + delta) % n)
+            (self.subject_combo.currentIndex() + delta) % n
+        )
 
     # ── Content area ───────────────────────────────────────────────────────────
 
@@ -224,8 +246,9 @@ class TasksLayout(Layout):
     # ── Button state management ────────────────────────────────────────────────
 
     def check_buttons(self) -> None:
-        subject_enabled = (not manager.state.task_is_running()
-                           and (self.testing_training or self.selected != ""))
+        subject_enabled = not manager.state.task_is_running() and (
+            self.testing_training or self.selected != ""
+        )
         self.subject_combo.setEnabled(subject_enabled)
         self.subject_up_button.setEnabled(subject_enabled)
         self.subject_down_button.setEnabled(subject_enabled)

--- a/village/gui/tasks_layout.py
+++ b/village/gui/tasks_layout.py
@@ -88,6 +88,11 @@ class TasksLayout(Layout):
         self._draw_content_area()
         self.check_buttons()
 
+        favourite = settings.get("FAVOURITE_TASK")
+        items = self._menu_items()
+        if favourite and favourite != "None" and favourite in items:
+            self.menu_list.setCurrentRow(items.index(favourite))
+
     # ── Left menu ──────────────────────────────────────────────────────────────
 
     def _draw_menu(self) -> None:
@@ -116,8 +121,10 @@ class TasksLayout(Layout):
         )
         self.menu_list.addItem(training_item)
 
+        favourite = settings.get("FAVOURITE_TASK")
         for key in manager.tasks:
-            item = QListWidgetItem(key)
+            label = f"★ {key}" if key == favourite else key
+            item = QListWidgetItem(label)
             item.setToolTip(f"Select the task {key}")
             self.menu_list.addItem(item)
 

--- a/village/settings.py
+++ b/village/settings.py
@@ -778,10 +778,7 @@ visual_settings = [
 
 hidden_settings = [
     Setting("FIRST_LAUNCH", "OFF", Active, "First launch of the system."),
-    Setting(
-        "LAST_SUBJECT", "None", str,
-        "The last subject selected in the TASKS tab."
-    ),
+    Setting("LAST_SUBJECT", "None", str, "The last subject selected in the TASKS tab."),
     Setting(
         "GITHUB_REPOSITORIES_DOWNLOADED",
         "OFF",

--- a/village/settings.py
+++ b/village/settings.py
@@ -48,6 +48,14 @@ tethered ephys or optogenetics recordings.""",
         """Enables the Operant Box PCB. This setting allows the Raspberry Pi to control
 some box components, such as LED stimuli, visible/infrared lighting, and motors.""",
     ),
+    Setting(
+        "FAVOURITE_TASK",
+        "None",
+        str,
+        """A favourite (★) task that is preselected when opening the TASKS
+        tab, so that the user can start a session immediately.
+        Set to None to disable preselection.""",
+    ),
 ]
 
 sound_settings = [

--- a/village/settings.py
+++ b/village/settings.py
@@ -779,6 +779,10 @@ visual_settings = [
 hidden_settings = [
     Setting("FIRST_LAUNCH", "OFF", Active, "First launch of the system."),
     Setting(
+        "LAST_SUBJECT", "None", str,
+        "The last subject selected in the TASKS tab."
+    ),
+    Setting(
         "GITHUB_REPOSITORIES_DOWNLOADED",
         "OFF",
         Active,


### PR DESCRIPTION
feature: favourite task (autoselected so can run immediately) in TASK tab, defined in settings
feature: subject selector for ergonomics
redesign: increase run task button size and subject selector next to it
bug fix? subject settings crash: when editing subjects settings and go idle, UI goes to main tab, the settings remain on screen, and Village crash when close because the TableView has already been deleted